### PR TITLE
feat: Add MPS support for Apple Silicon devices

### DIFF
--- a/src/gguf_connector/h2.py
+++ b/src/gguf_connector/h2.py
@@ -7,7 +7,7 @@ from higgs.data_types import ChatMLSample, Message
 
 MODEL_PATH = "callgg/higgs-f16"
 AUDIO_TOKENIZER_PATH = "callgg/higgs-encoder"
-DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 print(f"Using device: {DEVICE}")
 # System prompt
 system_prompt = (


### PR DESCRIPTION
This PR adds support for Apple Silicon (MPS), enabling GPU acceleration for users on modern Macs.
When trying to run 4-bit quantized GGUF models like `calcuis/higgs-gguf` on an Apple Silicon Mac, the only option was to use the CPU, which was quite slow. This change allows the model to utilize the MPS backend for a significant performance improvement, making the project much more usable for Mac users.

- Modified the device detection logic to include a check for `torch.backends.mps.is_available()`.
- The device selection priority is now: **CUDA -> MPS -> CPU**.