### PR TITLE
fix: prevent pipeline errors from being masked as invalid choice

### DIFF
--- a/src/gguf_connector/q6.py
+++ b/src/gguf_connector/q6.py
@@ -13,18 +13,19 @@ if gguf_files:
     try:
         choice_index = int(choice) - 1
         selected_file = gguf_files[choice_index]
-        print(f'Model file: {selected_file} is selected as image editor!')
-        input_path = selected_file
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        dtype = torch.bfloat16 if device == "cuda" else torch.float32
-        print(f"Device detected: {device}")
-        print(f"torch version: {torch.__version__}")
-        print(f"dtype using: {dtype}")
-        if device == "cuda":
-            print(f"running with: {torch.cuda.get_device_name(torch.cuda.current_device())}")
-        launch_image_edit_app(input_path,dtype)
     except (ValueError, IndexError):
         print('Invalid choice. Please enter a valid number.')
+        exit(1)
+    print(f'Model file: {selected_file} is selected as image editor!')
+    input_path = selected_file
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    print(f"Device detected: {device}")
+    print(f"torch version: {torch.__version__}")
+    print(f"dtype using: {dtype}")
+    if device == "cuda":
+        print(f"running with: {torch.cuda.get_device_name(torch.cuda.current_device())}")
+    launch_image_edit_app(input_path,dtype)
 else:
     print('No GGUF files are available in the current directory.')
     input('--- Press ENTER To Exit ---')


### PR DESCRIPTION
- ValueError/IndexError correctly handle only invalid input.
- Pipeline errors surface independently without being misreported.
- Improves correctness of error handling and user feedback.


## **Reproduction Steps**

**Before fix:**
```bash
$ ggc q6
GGUF file(s) available. Select which one to use:
1. qwen-image-edit-q8_0.gguf
Enter your choice (1 to 1): 1
Model file: qwen-image-edit-q8_0.gguf is selected as image editor!
Device detected: cuda
torch version: 2.8.0+cu129
dtype using: torch.bfloat16
running with: NVIDIA GeForce RTX 3060
`torch_dtype` is deprecated! Use `dtype` instead!
Loading pipeline components...: 100%|█████████████████████████████████████████| 6/6 [00:00<00:00, 10.99it/s]
Invalid choice. Please enter a valid number.
```

After inspecting the traceback:
```bash
ValueError: PEFT backend is required for this method.
```

**After installing PEFT:**
```bash
$ pip install peft
...
Successfully installed peft-0.17.1

$ ggc q6
GGUF file(s) available. Select which one to use:
1. qwen-image-edit-q8_0.gguf
Enter your choice (1 to 1): 1
Model file: qwen-image-edit-q8_0.gguf is selected as image editor!
Device detected: cuda
torch version: 2.8.0+cu129
dtype using: torch.bfloat16
running with: NVIDIA GeForce RTX 3060
`torch_dtype` is deprecated! Use `dtype` instead!
Loading pipeline components...: 100%|█████████████████████████████████████████| 6/6 [00:00<00:00, 10.75it/s]
lite.safetensors: 100%|██████████████████████████████████████████████████| 850M/850M [00:54<00:00, 15.7MB/s]
* Running on local URL:  http://127.0.0.1:7860
```