### PR TITLE
Support Multi-GPU Setup and External Access for Gradio application.

### DIFF
--- a/src/gguf_connector/q4.py
+++ b/src/gguf_connector/q4.py
@@ -86,7 +86,7 @@ def launch_qi_app(model_path,dtype):
             with gr.Column():
                 output_image = gr.Image(type="pil", label="Output Image")
         submit_btn.click(fn=generate_image, inputs=[prompt,num_steps,cfg_scale], outputs=output_image)
-    block.launch()
+    block.launch(server_name="0.0.0.0")
 
 def launch_qi_distill_app(model_path,dtype):
     transformer = QwenImageTransformer2DModel.from_single_file(
@@ -157,7 +157,7 @@ def launch_qi_distill_app(model_path,dtype):
             with gr.Column():
                 output_image = gr.Image(type="pil", label="Output Image")
         submit_btn.click(fn=generate_image, inputs=[prompt,num_steps], outputs=output_image)
-    block.launch()
+    block.launch(server_name="0.0.0.0")
 
 def launch_image_edit_app(model_path,dtype):
     transformer = QwenImageTransformer2DModel.from_single_file(
@@ -220,4 +220,4 @@ def launch_image_edit_app(model_path,dtype):
             with gr.Column():
                 output_image = gr.Image(type="pil", label="Output Image")
         submit_btn.click(fn=generate_image, inputs=[input_image,prompt,neg_prompt,guidance,num_steps], outputs=output_image)
-    block.launch()
+    block.launch(server_name="0.0.0.0")

--- a/src/gguf_connector/q4.py
+++ b/src/gguf_connector/q4.py
@@ -12,7 +12,7 @@ if _gpu_count > 1:
     max_memory = {}
     for i in range(_gpu_count):
         total_mb = torch.cuda.get_device_properties(i).total_memory // (1024 ** 2)
-        max_memory[f"cuda:{i}"] = f"{int(total_mb)}MB"
+        max_memory[i] = f"{int(total_mb)}MB"
 
     print("Using device_map:", device_map)
     print("Max memory per device:", max_memory)


### PR DESCRIPTION
## Summary

This pull request introduces support for multi-GPU environments with automatic device mapping and memory allocation, as well as exposes Gradio applications on all network interfaces to allow access from external devices.

### Multi-GPU Support

* Detects available GPUs when more than one is present.
* Prints detected GPU names for easier debugging and visibility.
* Configures `device_map="auto"` and assigns per-device `max_memory` dynamically.
* Integrates `device_map` and `max_memory` across:
  * `launch_qi_app`
  * `launch_qi_distill_app`
  * `launch_image_edit_app`

### Gradio Application Exposure

* Updated all `block.launch()` calls to include:
  ```python
  block.launch(server_name="0.0.0.0")
  ```
* Allows access to the Gradio UI from external devices on the same network.
