### PR TITLE
docs: Fix GGUF definition and author information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## GGUF connector
 
-GGUF (GPT-Generated Unified Format) is a successor of GGML (GPT-Generated Model Language), it was released on August 21, 2023; by the way, GPT stands for Generative Pre-trained Transformer.
+GGUF (Georgi Gerganov Unified Format) is a successor of GGML (Georgi Gerganov Machine Learning) a binary format for distributing large language models (LLMs) developed by [Georgi Gerganov](https://github.com/ggerganov).
 
 [<img src="https://raw.githubusercontent.com/calcuis/gguf-connector/master/gguf.gif" width="128" height="128">](https://github.com/calcuis/gguf-connector)
 [![Static Badge](https://img.shields.io/badge/version-2.9.0-green?logo=github)](https://github.com/calcuis/gguf-connector/releases)


### PR DESCRIPTION
The name GGML comes from its creator, Georgi Gerganov (GG), combined with ML for 'Machine Learning'. It does not stand for 'GPT-generated Model Language.'

Ref: https://github.com/rustformers/llm/tree/main/crates/ggml, https://changelog.com/podcast/532